### PR TITLE
Remove link to outdated docs repo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,3 +1,1 @@
 ## Welcome to the Lind Project!
-
-Learn more at our [docs page](https://github.com/Lind-Project/lind-docs)!


### PR DESCRIPTION
The relevant source code and docs repos are now pinned and thus prominently displayed on the GitHub org landing page, which makes a link in this README unnecessary.

see recommendations in: https://github.com/Lind-Project/lind-wasm/issues/145