### PR TITLE
Add default code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Code of Conduct
 
 The Lind Project follows the Contributor Covenant Code of Conduct hosted on the
-[project website](https://lind-project.github.io/lind-wasm-docs/contribute/conduct/).
+[project website](https://lind-project.github.io/lind-wasm-docs/community/conduct/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of Conduct
+
+The Lind Project follows the Contributor Covenant Code of Conduct hosted on the
+[project website](https://lind-project.github.io/lind-wasm-docs/contribute/conduct/).


### PR DESCRIPTION
~blocks on https://github.com/Lind-Project/lind-wasm-docs/pull/39~ (merged)

Add default CODE_OF_CONDUCT.md file for all projects under the Lind GitHub organization to canonical location as per the GitHub community standards.

The file only contains a reference to the actual code of conduct hosted on the project website.

Individual projects (repositories) may provide their own CODE_OF_CONDUCT.md to override the default.