### PR TITLE
Add default security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+Please refer to the security policy on the
+[project website](https://lind-project.github.io/lind-wasm-docs/contribute/security/).
+
+*NOTE: The policy covers [lind-wasm](https://github.com/Lind-Project/lind-wasm),
+which is the focus of Lind development. If you want to report a security issue
+for a different Lind project, you may still use this policy.*


### PR DESCRIPTION
~blocks on Lind-Project/lind-wasm-docs#38~ (merged)

Add default security policy file for all projects under the Lind GitHub organization as per the GitHub community standards. The added policy file contains a reference to the actual security policy hosted on the project website plus context info about lind-wasm (see below).

IMPORTANT: The security policy is relevant for the lind-wasm monorepo only, which is the focus of lind development (see
Lind-Project/lind-wasm#143). I think it makes sense to steer everyone there, even if they are comig from a different repo in the Lind org.

If that seems undesirable to others, I'm happy to move the file to the lind-wasm repo.