### PR TITLE
Add default contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing
+
+Please refer to the contributing guides on the [project website](https://lind-project.github.io/lind-wasm-docs/contribute).


### PR DESCRIPTION
~blocks on https://github.com/Lind-Project/lind-wasm-docs/pull/37~ (merged)

Add default contributing guide for all projects under the Lind GitHub organization as per the GitHub community standards. The added file file contains a reference to the actual contributing guides hosted on the project website.